### PR TITLE
NetHttp backend only normalizes URLs when necesary

### DIFF
--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -285,6 +285,8 @@ module Down
 
     # Makes sure that the URL is properly encoded.
     def addressable_normalize(url)
+      URI(url)
+    rescue URI::InvalidURIError
       addressable_uri = Addressable::URI.parse(url)
       addressable_uri.normalize.to_s
     end

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -233,6 +233,11 @@ describe Down do
       assert_equal "foo bar", tempfile.meta["etag"]
     end
 
+    it "only normalizes URLs when URI says the URL is invalid" do
+      Addressable::URI.expects(:parse).never
+      Down::NetHttp.download("#{$httpbin}/etag/2ELk8hUpTC2wqJ%2BZ%25GfTFA.jpg")
+    end
+
     it "raises on invalid URLs" do
       assert_raises(Down::InvalidUrl) { Down::NetHttp.download("foo://example.org") }
       assert_raises(Down::InvalidUrl) { Down::NetHttp.download("| ls") }

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -234,8 +234,9 @@ describe Down do
     end
 
     it "only normalizes URLs when URI says the URL is invalid" do
-      Addressable::URI.expects(:parse).never
-      Down::NetHttp.download("#{$httpbin}/etag/2ELk8hUpTC2wqJ%2BZ%25GfTFA.jpg")
+      url = "#{$httpbin}/etag/2ELk8hUpTC2wqJ%2BZ%25GfTFA.jpg"
+      tempfile = Down::NetHttp.download(url)
+      assert_equal url, tempfile.base_uri.to_s
     end
 
     it "raises on invalid URLs" do


### PR DESCRIPTION
We also hit the issue mentioned in #35 today and since no-one took a crack at the proposed solution yet, I thought I'd do it. 🙂 