### PR TITLE
Code fix for unknown HTTP error codes

### DIFF
--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -298,7 +298,11 @@ module Down
     def rebuild_response_from_open_uri_exception(exception)
       code, message = exception.io.status
 
-      response_class = Net::HTTPResponse::CODE_TO_OBJ.fetch(code)
+      response_class = Net::HTTPResponse::CODE_TO_OBJ.fetch(code) do |code|
+        Net::HTTPResponse::CODE_CLASS_TO_OBJ.fetch(code[0]) do
+          Net::HTTPUnknownResponse
+        end
+      end
       response       = response_class.new(nil, code, message)
 
       exception.io.metas.each do |name, values|

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -220,6 +220,14 @@ describe Down do
       error = assert_raises(Down::ServerError) { Down::NetHttp.download("#{$httpbin}/status/500") }
       assert_equal "500 Internal Server Error", error.message
       assert_kind_of Net::HTTPResponse, error.response
+
+      error = assert_raises(Down::ServerError) { Down::NetHttp.download("#{$httpbin}/status/599") }
+      assert_equal "599 Unknown", error.message
+      assert_kind_of Net::HTTPResponse, error.response
+
+      error = assert_raises(Down::ResponseError) { Down::NetHttp.download("#{$httpbin}/status/999") }
+      assert_equal "999 Unknown", error.message
+      assert_kind_of Net::HTTPResponse, error.response
     end
 
     it "accepts non-escaped URLs" do


### PR DESCRIPTION
Fix for unknown HTTP response codes that are not in `Net::HTTPResponse::CODE_TO_OBJ`.  

If code starts with '1', ..., '5' then assign the general `Net::HTTPResponse::CODE_TO_OBJ` code class.  Else assign `Net::HTTPUnknownResponse`.