### PR TITLE
Add Down::NotModified error to exception hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ the `Down::Error` subclasses. This is Down's exception hierarchy:
   * `Down::TooLarge`
   * `Down::InvalidUrl`
   * `Down::TooManyRedirects`
+  * `Down::NotModified`
   * `Down::ResponseError`
     * `Down::ClientError`
       * `Down::NotFound`

--- a/lib/down/errors.rb
+++ b/lib/down/errors.rb
@@ -13,6 +13,9 @@ module Down
   # raised when the number of redirects was larger than the specified maximum
   class TooManyRedirects < Error; end
 
+  # raised when the requested resource has not been modified
+  class NotModified < Error; end
+
   # raised when response returned 4xx or 5xx response
   class ResponseError < Error
     attr_reader :response

--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -216,9 +216,9 @@ module Down
         request_error!(exception)
       end
 
-    if response.is_a?(Net::HTTPNotModified)
-      raise Down::NotModified
-    elsif response.is_a?(Net::HTTPRedirection)
+      if response.is_a?(Net::HTTPNotModified)
+        raise Down::NotModified
+      elsif response.is_a?(Net::HTTPRedirection)
         raise Down::TooManyRedirects if follows_remaining == 0
 
         # fail if redirect URI is not a valid http or https URL

--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -216,7 +216,9 @@ module Down
         request_error!(exception)
       end
 
-      if response.is_a?(Net::HTTPRedirection)
+    if response.is_a?(Net::HTTPNotModified)
+      raise Down::NotModified
+    elsif response.is_a?(Net::HTTPRedirection)
         raise Down::TooManyRedirects if follows_remaining == 0
 
         # fail if redirect URI is not a valid http or https URL

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -421,6 +421,10 @@ describe Down do
       assert_raises(Down::ResponseError) { Down::NetHttp.open("#{$httpbin}/redirect-to?url=#{CGI.escape("ftp://localhost/file.txt")}") }
     end
 
+    it "raises on redirect not modfied" do
+      assert_raises(Down::NotModified) { Down::NetHttp.open("#{$httpbin}/status/304") }
+    end
+
     it "raises on connection errors" do
       assert_raises(Down::ConnectionError) { Down::NetHttp.open("http://localhost:99999") }
     end


### PR DESCRIPTION
Issue described here: https://github.com/janko/down/issues/52

- Currently, if Down::NetHttp receives a 304 Not Modified response, it ends up throwing an ArgumentError. 
- This PR adds a check for `Net::HTTPNotModified` in net_http_request, and raises a `Down::NotModified` error.