### PR TITLE
Allow http 5-x

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,8 @@ net_http.open("http://example.com/image.jpg")
 The `Down::Http` backend implements downloads using the [http.rb] gem.
 
 ```rb
-gem "down", "~> 4.4"
-gem "http", "~> 4.0"
+gem "down", "~> 5.0"
+gem "http", "~> 5.0"
 ```
 ```rb
 require "down/http"

--- a/down.gemspec
+++ b/down.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "mocha", "~> 1.5"
   spec.add_development_dependency "rake"
+  # http 5.0 drop support of ruby 2.3 and 2.4. We still support those versions.
   if RUBY_VERSION >= "2.5"
     spec.add_development_dependency "http", "~> 5.0"
   else

--- a/down.gemspec
+++ b/down.gemspec
@@ -20,7 +20,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "mocha", "~> 1.5"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "http", "~> 5.0"
+  if RUBY_VERSION >= "2.5"
+    spec.add_development_dependency "http", "~> 5.0"
+  else
+    spec.add_development_dependency "http", "~> 4.3"
+  end
   spec.add_development_dependency "posix-spawn" unless RUBY_ENGINE == "jruby"
   spec.add_development_dependency "http_parser.rb"
   spec.add_development_dependency "docker-api"

--- a/down.gemspec
+++ b/down.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "mocha", "~> 1.5"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "http", "~> 4.3"
+  spec.add_development_dependency "http", "~> 5.0"
   spec.add_development_dependency "posix-spawn" unless RUBY_ENGINE == "jruby"
   spec.add_development_dependency "http_parser.rb"
   spec.add_development_dependency "docker-api"

--- a/lib/down/http.rb
+++ b/lib/down/http.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-gem "http", ">= 2.1.0", "< 5"
+gem "http", ">= 2.1.0", "< 6"
 
 require "http"
 

--- a/test/support/warnings.rb
+++ b/test/support/warnings.rb
@@ -2,5 +2,4 @@ if RUBY_VERSION >= "2.4"
   require "warning"
 
   Warning.process('', /instance variable @\w+ not initialized/ => :raise)
-  Warning.ignore(/interpreted as argument prefix/, Gem::Specification.find_by_name("http-parser").load_paths.first)
 end

--- a/test/support/warnings.rb
+++ b/test/support/warnings.rb
@@ -2,4 +2,9 @@ if RUBY_VERSION >= "2.4"
   require "warning"
 
   Warning.process('', /instance variable @\w+ not initialized/ => :raise)
+
+  # ruby 2.5 or higher uses http.rb 5.0 which doesn't have http-parser as a dependency
+  if RUBY_VERSION < "2.5"
+    Warning.ignore(/interpreted as argument prefix/, Gem::Specification.find_by_name("http-parser").load_paths.first)
+  end
 end


### PR DESCRIPTION
`http` 5.0.0 has released a few days ago.

The PR adds support for 5.x.

`http` drop Ruby 2.3 and 2.4 support (httprb/http#571 and [this commit](https://github.com/httprb/http/commit/3ed0c318eab6a8c390654cda17bf6df9e963c7d6)). That's why I'm using 4.x on CI when ruby is lower than 2.5.0.