### PR TITLE
Add info about content size to Down::TooLarge error

### DIFF
--- a/lib/down/http.rb
+++ b/lib/down/http.rb
@@ -31,7 +31,7 @@ module Down
       content_length_proc.call(response.content_length) if content_length_proc && response.content_length
 
       if max_size && response.content_length && response.content_length > max_size
-        raise Down::TooLarge, "file is too large (max is #{max_size/1024/1024}MB)"
+        raise Down::TooLarge, "file is too large (#{response.content_length/1024/1024}MB, max is #{max_size/1024/1024}MB)"
       end
 
       extname  = File.extname(response.uri.path)
@@ -44,7 +44,7 @@ module Down
         progress_proc.call(tempfile.size) if progress_proc
 
         if max_size && tempfile.size > max_size
-          raise Down::TooLarge, "file is too large (max is #{max_size/1024/1024}MB)"
+          raise Down::TooLarge, "file is too large (#{tempfile.size/1024/1024}MB, max is #{max_size/1024/1024}MB)"
         end
       end
 

--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -49,13 +49,13 @@ module Down
       open_uri_options = {
         content_length_proc: proc { |size|
           if size && max_size && size > max_size
-            raise Down::TooLarge, "file is too large (max is #{max_size/1024/1024}MB)"
+            raise Down::TooLarge, "file is too large (#{size/1024/1024}MB, max is #{max_size/1024/1024}MB)"
           end
           content_length_proc.call(size) if content_length_proc
         },
         progress_proc: proc { |current_size|
           if max_size && current_size > max_size
-            raise Down::TooLarge, "file is too large (max is #{max_size/1024/1024}MB)"
+            raise Down::TooLarge, "file is too large (#{current_size/1024/1024}MB, max is #{max_size/1024/1024}MB)"
           end
           progress_proc.call(current_size) if progress_proc
         },

--- a/lib/down/wget.rb
+++ b/lib/down/wget.rb
@@ -35,7 +35,7 @@ module Down
       content_length_proc.call(io.size) if content_length_proc && io.size
 
       if max_size && io.size && io.size > max_size
-        raise Down::TooLarge, "file is too large (max is #{max_size/1024/1024}MB)"
+        raise Down::TooLarge, "file is too large (#{io.size/1024/1024}MB, max is #{max_size/1024/1024}MB)"
       end
 
       extname  = File.extname(URI(url).path)
@@ -49,7 +49,7 @@ module Down
         progress_proc.call(tempfile.size) if progress_proc
 
         if max_size && tempfile.size > max_size
-          raise Down::TooLarge, "file is too large (max is #{max_size/1024/1024}MB)"
+          raise Down::TooLarge, "file is too large (#{tempfile.size/1024/1024}MB, max is #{max_size/1024/1024}MB)"
         end
       end
 

--- a/test/http_test.rb
+++ b/test/http_test.rb
@@ -46,9 +46,10 @@ describe Down::Http do
     end
 
     it "accepts maximum size" do
-      assert_raises(Down::TooLarge) do
+      error = assert_raises(Down::TooLarge) do
         Down::Http.download("#{$httpbin}/bytes/10", max_size: 5)
       end
+      assert_match "file is too large (0MB, max is 0MB)", error.message
 
       assert_raises(Down::TooLarge) do
         Down::Http.download("#{$httpbin}/stream-bytes/10", max_size: 5)

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -66,9 +66,10 @@ describe Down do
     end
 
     it "accepts max size" do
-      assert_raises(Down::TooLarge) do
+      error = assert_raises(Down::TooLarge) do
         Down::NetHttp.download("#{$httpbin}/bytes/10", max_size: 5)
       end
+      assert_match "file is too large (0MB, max is 0MB)", error.message
 
       assert_raises(Down::TooLarge) do
         Down::NetHttp.download("#{$httpbin}/stream-bytes/10", max_size: 5)

--- a/test/wget_test.rb
+++ b/test/wget_test.rb
@@ -22,9 +22,10 @@ describe Down::Wget do
     end
 
     it "accepts maximum size" do
-      assert_raises(Down::TooLarge) do
+      error = assert_raises(Down::TooLarge) do
         Down::Wget.download("#{$httpbin}/bytes/10", max_size: 5)
       end
+      assert_match "file is too large (0MB, max is 0MB)", error.message
 
       assert_raises(Down::TooLarge) do
         Down::Wget.download("#{$httpbin}/stream-bytes/10", max_size: 5)


### PR DESCRIPTION
Hey!

I've added more info about the content size to `Down::TooLarge`. It's very handy for debugging to have that info