### PR TITLE
Keep cookies between redirections (net_http)

### DIFF
--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -158,7 +158,11 @@ module Down
 
       # forward cookies on the redirect
       if !exception.io.meta["set-cookie"].to_s.empty?
-        options["Cookie"] = exception.io.meta["set-cookie"]
+        options["Cookie"] ||= ''
+        # Add new cookies avoiding duplication
+        new_cookies = exception.io.meta["set-cookie"].to_s.split(',').map(&:strip)
+        old_cookies = options["Cookie"].split(',')
+        options["Cookie"] = (old_cookies | new_cookies).join(',')
       end
 
       follows_remaining -= 1


### PR DESCRIPTION
## Why
When the gem tries to forward the cookies only pass the last one. In some 'GETs' is needed to send all the cookies that you have received in the previous requests. In another case, the URL can't be accessed.

## What
This PR only build a concatenation with all the cookies received during the redirects only keeping key and value. The rest of the cookies data like TTL, etc. are skipped.
