### PR TITLE
Allow passing explicit extension name

### DIFF
--- a/lib/down/http.rb
+++ b/lib/down/http.rb
@@ -25,7 +25,7 @@ module Down
 
     # Downlods the remote file to disk. Accepts HTTP.rb options via a hash or a
     # block, and some additional options as well.
-    def download(url, max_size: nil, progress_proc: nil, content_length_proc: nil, destination: nil, **options, &block)
+    def download(url, max_size: nil, progress_proc: nil, content_length_proc: nil, destination: nil, extension: nil, **options, &block)
       response = request(url, **options, &block)
 
       content_length_proc.call(response.content_length) if content_length_proc && response.content_length
@@ -34,7 +34,7 @@ module Down
         raise Down::TooLarge, "file is too large (#{response.content_length/1024/1024}MB, max is #{max_size/1024/1024}MB)"
       end
 
-      extname  = File.extname(response.uri.path)
+      extname  = extension || File.extname(response.uri.path)
       tempfile = Tempfile.new(["down-http", extname], binmode: true)
 
       stream_body(response) do |chunk|

--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -40,6 +40,7 @@ module Down
       destination         = options.delete(:destination)
       headers             = options.delete(:headers)
       uri_normalizer      = options.delete(:uri_normalizer)
+      extension           = options.delete(:extension)
 
       # Use open-uri's :content_lenth_proc or :progress_proc to raise an
       # exception early if the file is too large.
@@ -93,7 +94,7 @@ module Down
       open_uri_file = open_uri(uri, open_uri_options, follows_remaining: max_redirects)
 
       # Handle the fact that open-uri returns StringIOs for small files.
-      tempfile = ensure_tempfile(open_uri_file, File.extname(open_uri_file.base_uri.path))
+      tempfile = ensure_tempfile(open_uri_file, extension || File.extname(open_uri_file.base_uri.path))
       OpenURI::Meta.init tempfile, open_uri_file # add back open-uri methods
       tempfile.extend Down::NetHttp::DownloadedFile
 

--- a/lib/down/wget.rb
+++ b/lib/down/wget.rb
@@ -29,7 +29,7 @@ module Down
 
     # Downlods the remote file to disk. Accepts wget command-line options and
     # some additional options as well.
-    def download(url, *args, max_size: nil, content_length_proc: nil, progress_proc: nil, destination: nil, **options)
+    def download(url, *args, max_size: nil, content_length_proc: nil, progress_proc: nil, destination: nil, extension: nil, **options)
       io = open(url, *args, **options, rewindable: false)
 
       content_length_proc.call(io.size) if content_length_proc && io.size
@@ -38,7 +38,7 @@ module Down
         raise Down::TooLarge, "file is too large (#{io.size/1024/1024}MB, max is #{max_size/1024/1024}MB)"
       end
 
-      extname  = File.extname(URI(url).path)
+      extname  = extension || File.extname(URI(url).path)
       tempfile = Tempfile.new(["down-wget", extname], binmode: true)
 
       until io.eof?

--- a/test/http_test.rb
+++ b/test/http_test.rb
@@ -71,6 +71,9 @@ describe Down::Http do
 
       tempfile = Down::Http.download("#{$httpbin}/redirect-to", params: { url: "#{$httpbin}/robots.txt" })
       assert_equal ".txt", File.extname(tempfile.path)
+
+      tempfile = Down::Http.download("#{$httpbin}/robots/", extension: "txt")
+      assert_equal ".txt", File.extname(tempfile.path)
     end
 
     it "accepts :content_length_proc" do

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -53,6 +53,9 @@ describe Down do
 
       tempfile = Down::NetHttp.download("#{$httpbin}/redirect-to?url=#{$httpbin}/robots.txt")
       assert_equal ".txt", File.extname(tempfile.path)
+
+      tempfile = Down::NetHttp.download("#{$httpbin}/robots/", extension: "txt")
+      assert_equal ".txt", File.extname(tempfile.path)
     end
 
     it "accepts an URI object" do

--- a/test/wget_test.rb
+++ b/test/wget_test.rb
@@ -65,6 +65,9 @@ describe Down::Wget do
 
       tempfile = Down::Wget.download("#{$httpbin}/robots.txt?foo=bar")
       assert_equal ".txt", File.extname(tempfile.path)
+
+      tempfile = Down::Wget.download("#{$httpbin}/robots/", extension: 'txt')
+      assert_equal ".txt", File.extname(tempfile.path)
     end
 
     it "adds #headers and #url" do


### PR DESCRIPTION
Some s3-like apis return urls and those query strings don't end with a normal file extension.
Let's allow to explicitly pass that