### PR TITLE
Normalize response headers for http.rb and wget backends

### DIFF
--- a/lib/down/backend.rb
+++ b/lib/down/backend.rb
@@ -29,5 +29,12 @@ module Down
 
       nil
     end
+
+    def normalize_headers(response_headers)
+      response_headers.inject({}) do |headers, (downcased_name, value)|
+        name = downcased_name.split("-").map(&:capitalize).join("-")
+        headers.merge!(name => value)
+      end
+    end
   end
 end

--- a/lib/down/http.rb
+++ b/lib/down/http.rb
@@ -71,7 +71,11 @@ module Down
         size:       response.content_length,
         encoding:   response.content_type.charset,
         rewindable: rewindable,
-        data:       { status: response.code, headers: response.headers.to_h, response: response },
+        data:       {
+          status:   response.code,
+          headers:  normalize_headers(response.headers.to_h),
+          response: response
+        },
       )
     end
 

--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -130,10 +130,7 @@ module Down
         on_close:   -> { request.resume }, # close HTTP connnection
         data: {
           status:   response.code.to_i,
-          headers:  response.each_header.inject({}) { |headers, (downcased_name, value)|
-                      name = downcased_name.split("-").map(&:capitalize).join("-")
-                      headers.merge!(name => value)
-                    },
+          headers:  normalize_headers(response.each_header),
           response: response,
         },
       )

--- a/lib/down/wget.rb
+++ b/lib/down/wget.rb
@@ -94,7 +94,7 @@ module Down
         raise Down::Error, "failed to parse response headers"
       end
 
-      headers = parser.headers
+      headers = normalize_headers(parser.headers)
       status  = parser.status_code
 
       content_length = headers["Content-Length"].to_i if headers["Content-Length"]

--- a/test/http_test.rb
+++ b/test/http_test.rb
@@ -233,9 +233,10 @@ describe Down::Http do
     end
 
     it "saves response data" do
-      io = Down::Http.open("#{$httpbin}/response-headers?Foo=Bar")
+      io = Down::Http.open("#{$httpbin}/response-headers?Foo=Bar&bar=baz")
       assert_equal 200,                  io.data[:status]
       assert_equal "Bar",                io.data[:headers]["Foo"]
+      assert_equal "baz",                io.data[:headers]["Bar"]
       assert_instance_of HTTP::Response, io.data[:response]
     end
 

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -387,8 +387,9 @@ describe Down do
     end
 
     it "saves response data" do
-      io = Down::NetHttp.open("#{$httpbin}/response-headers?Key=Value")
+      io = Down::NetHttp.open("#{$httpbin}/response-headers?Key=Value&bar=baz")
       assert_equal "Value",             io.data[:headers]["Key"]
+      assert_equal "baz",               io.data[:headers]["Bar"]
       assert_equal 200,                 io.data[:status]
       assert_kind_of Net::HTTPResponse, io.data[:response]
     end

--- a/test/wget_test.rb
+++ b/test/wget_test.rb
@@ -206,9 +206,10 @@ describe Down::Wget do
     end
 
     it "saves response data" do
-      io = Down::Wget.open("#{$httpbin}/response-headers?Header=Value")
+      io = Down::Wget.open("#{$httpbin}/response-headers?Header=Value&bar=baz")
       assert_equal 200,     io.data[:status]
       assert_equal "Value", io.data[:headers]["Header"]
+      assert_equal "baz",   io.data[:headers]["Bar"]
     end
 
     it "closes the command" do


### PR DESCRIPTION
http.rb v5 changed header handling and no longer normalizes header casing for requests or responses (httprb/http#576). The wget backend also didn't normalize response headers.

The net-http backend normalizes headers already, so this PR adds the same normalization to the http.rb and wget backends.

In the case of wget, it also likely fixes detection of Content-Length and Content-Type if the upstream served those using non-normalized casing.

Strictly speaking, this could be seen as a breaking change when using the http.rb (but only with http.rb v5) or wget backends if app code was relying on the previous non-normalized casing with a particular upstream server. Such code would be fragile though, as the casing can vary based on the upstream server.

At the same time, it's also a needed bug fix since http.rb v4 and v5 behave differently, as well as the above mentioned issue with wget.