### PR TITLE
Do not ignore encoding just because a read length is given

### DIFF
--- a/lib/down/chunked_io.rb
+++ b/lib/down/chunked_io.rb
@@ -77,7 +77,7 @@ module Down
 
       buffer.clear if buffer # deallocate string
 
-      data.force_encoding(@encoding) unless length
+      data.force_encoding(@encoding)
       data unless data.empty? && length && length > 0
     end
 

--- a/test/chunked_io_test.rb
+++ b/test/chunked_io_test.rb
@@ -154,16 +154,16 @@ describe Down::ChunkedIO do
         assert_equal "bc", io.read(2)
       end
 
-      it "returns content in binary encoding" do
+      it "returns content in requested encoding" do
         io = chunked_io(chunks: ["ab", "c"].each)
         assert_equal Encoding::BINARY, io.read(1).encoding
         io.rewind
         assert_equal Encoding::BINARY, io.read(1).encoding
 
         io = chunked_io(chunks: ["ab", "c"].each, encoding: "utf-8")
-        assert_equal Encoding::BINARY, io.read(1).encoding
+        assert_equal Encoding::UTF_8, io.read(1).encoding
         io.rewind
-        assert_equal Encoding::BINARY, io.read(1).encoding
+        assert_equal Encoding::UTF_8, io.read(1).encoding
       end
     end
 
@@ -249,16 +249,16 @@ describe Down::ChunkedIO do
         assert_equal "bc", io.read(2, "")
       end
 
-      it "returns content in binary encoding" do
+      it "returns content in requested encoding" do
         io = chunked_io(chunks: ["ab", "c"].each)
         assert_equal Encoding::BINARY, io.read(1, "").encoding
         io.rewind
         assert_equal Encoding::BINARY, io.read(1, "").encoding
 
         io = chunked_io(chunks: ["ab", "c"].each, encoding: "utf-8")
-        assert_equal Encoding::BINARY, io.read(1, "").encoding
+        assert_equal Encoding::UTF_8, io.read(1, "").encoding
         io.rewind
-        assert_equal Encoding::BINARY, io.read(1, "").encoding
+        assert_equal Encoding::UTF_8, io.read(1, "").encoding
       end
     end
 


### PR DESCRIPTION
In the current implementation, `Down::ChunkedIO` has a very curious piece of behaviour where it deliberately ignores requested character encoding in `#read` if and only if a read length is given. This breaks our application.

I'm not sure why this is done. Perhaps there was a suspicion that Ruby's `#force_encoding` method might change the byte length of the data, leading to the `length` parameter not being honoured - but this is 100% not the case:

* https://ruby-doc.org/core-2.5.0/Encoding.html#class-Encoding-label-Changing+an+encoding

> "First, it is possible to set the [Encoding](https://ruby-doc.org/core-2.5.0/Encoding.html) of a string to a new [Encoding](https://ruby-doc.org/core-2.5.0/Encoding.html) without changing the internal byte representation of the string, with [String#force_encoding](https://ruby-doc.org/core-2.5.0/String.html#method-i-force_encoding)."

It would make no sense for `#force_encoding` to change the data itself, since the whole point is to merely indicate via metadata _how_ that identical byte representation is to be interpreted for character presentation. The documentation  for `Down::ChunkedIO#read` specifically says _bytes_ not characters in its documentation:

* https://www.rubydoc.info/gems/down/5.2.0/Down%2FChunkedIO:read

> "With `length` argument returns exactly that number of bytes if they're available."

...so encoding can and should be respected; `#force_encoding` is the right way to do it; and the presence of a `length` parameter should not influence that behaviour.

This PR changes behaviour accordingly, with appropriately updated tests.