### PR TITLE
Normalize headers for HTTP downloads.

### DIFF
--- a/lib/down/http.rb
+++ b/lib/down/http.rb
@@ -52,7 +52,7 @@ module Down
 
       tempfile.extend Down::Http::DownloadedFile
       tempfile.url     = response.uri.to_s
-      tempfile.headers = response.headers.to_h
+      tempfile.headers = normalize_headers(response.headers.to_h)
 
       download_result(tempfile, destination)
     rescue


### PR DESCRIPTION
Hello,

I came across an issue where a server was returning a lowercase `content-type` header.

Unfortunately, this makes it so [`content_type`](https://github.com/janko/down/blob/c85cc7d7cec85b8a01816492bbe804a73aab1c86/lib/down/http.rb#L150) returns `nil`, when using `Down::Http.download`.

Fortunately, a solution was already introduced in #68, but it only fixed downloads initiated with `Down::Http.open`. This PR makes it also work with `download`.

Before

```ruby
file = Down.download("https://micro.blog/photos/1000x/https%3A%2F%2Flson.micro.blog%2Fuploads%2F2022%2F9846e54a80.jpg")
file.content_type #=> nil
```

After

```ruby
file = Down.download("https://micro.blog/photos/1000x/https%3A%2F%2Flson.micro.blog%2Fuploads%2F2022%2F9846e54a80.jpg")
file.content_type #=> image/jpeg
```

Thanks for making down!