### PR TITLE
Add ability to detect response URI when using NetHttp

### DIFF
--- a/lib/down/net_http.rb
+++ b/lib/down/net_http.rb
@@ -270,7 +270,7 @@ module Down
       headers = options[:headers].to_h
       headers["Accept-Encoding"] = "" # Net::HTTP's inflater causes FiberErrors
 
-      get = Net::HTTP::Get.new(uri.request_uri, headers)
+      get = Net::HTTP::Get.new(uri, headers)
 
       user, password = options[:http_basic_authentication] || [uri.user, uri.password]
       get.basic_auth(user, password) if user || password

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -401,6 +401,16 @@ describe Down do
       assert_kind_of Net::HTTPResponse, io.data[:response]
     end
 
+    # The response URI is only available if a URI was used to create the request.
+    # https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTPResponse.html#uri
+    it "constructs http response with #uri attribute set" do
+      io = Down::NetHttp.open("#{$httpbin}/get")
+      assert_equal URI("#{$httpbin}/get"), io.data[:response].uri
+
+      io = Down::NetHttp.open("#{$httpbin}/redirect/1")
+      assert_equal URI("#{$httpbin}/get"), io.data[:response].uri # redirected uri
+    end
+
     it "raises on HTTP error responses" do
       error = assert_raises(Down::ClientError) { Down::NetHttp.open("#{$httpbin}/status/404") }
       assert_equal "404 Not Found", error.message


### PR DESCRIPTION
NetHttp::Response set `#uri` attribute only when request was made using URI.

This can be used to find final URI after redirects.

```ruby
io = Down::NetHttp.open("#{$httpbin}/redirect/1")

# previously
io.data[:response].uri # => nil

# now
io.data[:response].uri # => URI("#{$httpbin}/get")
```