### PR TITLE
Fixing tests

### DIFF
--- a/test/chunked_io_test.rb
+++ b/test/chunked_io_test.rb
@@ -829,19 +829,19 @@ describe Down::ChunkedIO do
 
   describe "#inspect" do
     it "shows important information" do
-      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:ASCII-8BIT> data={} on_close=nil rewindable=true>",
+      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:BINARY (ASCII-8BIT)> data={} on_close=nil rewindable=true>",
                    chunked_io(chunks: [""].each).inspect
-      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=10 encoding=#<Encoding:ASCII-8BIT> data={} on_close=nil rewindable=true>",
+      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=10 encoding=#<Encoding:BINARY (ASCII-8BIT)> data={} on_close=nil rewindable=true>",
                    chunked_io(chunks: [""].each, size: 10).inspect
       assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:UTF-8> data={} on_close=nil rewindable=true>",
                    chunked_io(chunks: [""].each, encoding: "utf-8").inspect
-      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:ASCII-8BIT> data={:foo=>\"bar\"} on_close=nil rewindable=true>",
+      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:BINARY (ASCII-8BIT)> data={foo: \"bar\"} on_close=nil rewindable=true>",
                    chunked_io(chunks: [""].each, data: {foo: "bar"}).inspect
-      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:ASCII-8BIT> data={} on_close=:callable rewindable=true>",
+      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:BINARY (ASCII-8BIT)> data={} on_close=:callable rewindable=true>",
                    chunked_io(chunks: [""].each, on_close: :callable).inspect
-      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:ASCII-8BIT> data={} on_close=nil rewindable=false>",
+      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:BINARY (ASCII-8BIT)> data={} on_close=nil rewindable=false>",
                    chunked_io(chunks: [""].each, rewindable: false).inspect
-      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:ASCII-8BIT> data={} on_close=nil rewindable=true (closed)>",
+      assert_equal "#<Down::ChunkedIO chunks=#<Enumerator: [\"\"]:each> size=nil encoding=#<Encoding:BINARY (ASCII-8BIT)> data={} on_close=nil rewindable=true (closed)>",
                    chunked_io(chunks: [""].each).tap(&:close).inspect
     end
   end

--- a/test/httpx_test.rb
+++ b/test/httpx_test.rb
@@ -152,7 +152,7 @@ describe Down::Httpx do
     it "adds #charset extracted from Content-Type" do
       tempfile = Down::Httpx.download("#{$httpbin}/html")
       assert_equal "text/html", tempfile.content_type
-      assert_equal "utf-8", tempfile.charset
+      assert_equal "UTF-8", tempfile.charset.name
     end
 
     it "accepts download destination" do


### PR DESCRIPTION
For issue #93 

Effectively, we're changing the text to match the output which on principle is not great. I think maybe matching the text of inspect is brittle and these tests need a re-think. 

The text change on encoding I believe came from this [change]( https://github.com/ruby/ruby/commit/3a7846b1aa4c10d86dc5a91c6df94f89d60bb0c3). So this does not pass on ruby 3.3.6, but does pass on 3.4.1 (not sure exactly which release that change came out in). 



