### PR TITLE
Support http.rb 6.0

### DIFF
--- a/down.gemspec
+++ b/down.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "httpx", "~> 1.0", "< 1.4.4"
-  spec.add_development_dependency "http", "~> 5.0"
+  spec.add_development_dependency "http", "~> 6.0"
   spec.add_development_dependency "warning"
   spec.add_development_dependency "csv"
 end

--- a/lib/down/http.rb
+++ b/lib/down/http.rb
@@ -1,8 +1,9 @@
 # frozen-string-literal: true
 
-gem "http", ">= 2.1.0", "< 6"
+gem "http", ">= 2.1.0", "< 7"
 
 require "http"
+require "addressable/uri"
 
 require "down/backend"
 
@@ -19,7 +20,10 @@ module Down
         .follow(max_hops: 2)
         .timeout(connect: 30, write: 30, read: 30)
 
-      @client = HTTP::Client.new(@client.default_options.merge(options)) if options.any?
+      if options.any?
+        client_class = defined?(HTTP::Session) ? HTTP::Session : HTTP::Client
+        @client = client_class.new(@client.default_options.merge(options))
+      end
       @client = block.call(@client) if block
     end
 
@@ -94,7 +98,7 @@ module Down
       client = client.basic_auth(user: uri.user, pass: uri.password) if uri.user || uri.password
       client = block.call(client) if block
 
-      client.request(method, url, options)
+      client.request(method, url, **options)
     rescue => exception
       request_error!(exception)
     end
@@ -123,7 +127,7 @@ module Down
     # Re-raise HTTP.rb exceptions as Down::Error exceptions.
     def request_error!(exception)
       case exception
-      when HTTP::Request::UnsupportedSchemeError, Addressable::URI::InvalidURIError
+      when HTTP::Request::UnsupportedSchemeError, Addressable::URI::InvalidURIError, *invalid_url_errors
         raise Down::InvalidUrl, exception.message
       when HTTP::ConnectionError
         raise Down::ConnectionError, exception.message
@@ -136,6 +140,10 @@ module Down
       else
         raise exception
       end
+    end
+
+    def invalid_url_errors
+      defined?(HTTP::URI::InvalidError) ? [HTTP::URI::InvalidError] : []
     end
 
     # Defines some additional attributes for the returned Tempfile.

--- a/test/http_test.rb
+++ b/test/http_test.rb
@@ -312,8 +312,8 @@ describe Down::Http do
       assert_equal "500 Internal Server Error", error.message
       assert_instance_of HTTP::Response, error.response
 
-      error = assert_raises(Down::ResponseError) { Down::Http.open("#{$httpbin}/status/100") }
-      assert_equal "100 Continue", error.message
+      error = assert_raises(Down::ResponseError) { Down::Http.open("#{$httpbin}/status/305") }
+      assert_equal "305 Use Proxy", error.message
       assert_instance_of HTTP::Response, error.response
     end
 


### PR DESCRIPTION
This patch adds support for v6 of the `http` gem, while maintaining support for earlier versions going back to 2.1.0.

There were various [changes to the public API in v6](https://github.com/httprb/http/blob/main/UPGRADING.md), including:
* Chainable methods now return an `HTTP::Session` instead of an `HTTP::Client`
* Options are now passed as keyword arguments instead of a `Hash`
* Malformed URIs now raise an `HTTP::URI::InvalidError`
* Addressable is now an optional dependency, so it needs to be explicitly required
* 1xx responses are now transparently skiped